### PR TITLE
[Refactor] 프로필 페이지 전적 불러오기 리팩토링

### DIFF
--- a/backend/nestjs-app/src/match_history/dto/history.dto.ts
+++ b/backend/nestjs-app/src/match_history/dto/history.dto.ts
@@ -1,23 +1,36 @@
-import { IsNumber, IsString, IsNotEmpty } from 'class-validator';
+import { IsNumber, IsString, IsNotEmpty, IsObject } from 'class-validator';
+import { User } from 'src/users/entities/user.entity';
 
 export class HistoryDto {
   @IsNumber()
   @IsNotEmpty()
-  player1score: number;
+  player1Score: number;
 
   @IsNumber()
   @IsNotEmpty()
-  player2score: number;
+  player2Score: number;
+
+  @IsNumber()
+  @IsNotEmpty()
+  player1ScoreChange: number;
+
+  @IsNumber()
+  @IsNotEmpty()
+  player2ScoreChange: number;
+
+  @IsObject()
+  @IsNotEmpty()
+  player1: User;
+
+  @IsObject()
+  @IsNotEmpty()
+  player2: User;
 
   @IsString()
   @IsNotEmpty()
-  player1: string;
+  roomType: string;
 
   @IsString()
   @IsNotEmpty()
-  player2: string;
-
-  @IsString()
-  @IsNotEmpty()
-  gameMode: string;
+  map: string;
 }

--- a/backend/nestjs-app/src/match_history/entities/match_history.entity.ts
+++ b/backend/nestjs-app/src/match_history/entities/match_history.entity.ts
@@ -17,7 +17,13 @@ export class MatchHistory extends BaseEntity {
   player1Score: number;
 
   @Column()
+  player1ScoreChange: number;
+
+  @Column()
   player2Score: number;
+
+  @Column()
+  player2ScoreChange: number;
 
   @CreateDateColumn()
   createdAt: Date;
@@ -33,5 +39,8 @@ export class MatchHistory extends BaseEntity {
   player2: User;
 
   @Column()
-  gameMode: string;
+  roomType: string;
+
+  @Column()
+  map: string;
 }

--- a/backend/nestjs-app/src/match_history/history.controller.ts
+++ b/backend/nestjs-app/src/match_history/history.controller.ts
@@ -12,17 +12,10 @@ export class MatchHistorysController {
     private matchHistoryService: MatchHistorysService,
     private userService: UsersService,
   ) {}
-  @Get('/:nickname')
-  async getHistoryByNickname(
-    @Param() params: NicknameParamDto,
-  ): Promise<MatchHistory[]> {
-    return await this.matchHistoryService.getHistoryJoinUserByNickname(
-      params.nickname,
-    );
-  }
 
   @Get('/:id')
   async getHistoryById(@Param() params: IdParamDto): Promise<MatchHistory[]> {
+    console.log('here', params);
     return await this.matchHistoryService.getHistoryJoinUserById(params.id);
   }
 }

--- a/backend/nestjs-app/src/match_history/history.controller.ts
+++ b/backend/nestjs-app/src/match_history/history.controller.ts
@@ -12,18 +12,6 @@ export class MatchHistorysController {
     private matchHistoryService: MatchHistorysService,
     private userService: UsersService,
   ) {}
-
-  @Post('/')
-  async putHistory(@Body() historyDto: HistoryDto) {
-    try {
-      const player1 = await this.userService.getUserById(historyDto.player1);
-      const player2 = await this.userService.getUserById(historyDto.player2);
-      await this.matchHistoryService.putHistory(historyDto, player1, player2);
-    } catch (e) {
-      throw e;
-    }
-  }
-
   @Get('/:nickname')
   async getHistoryByNickname(
     @Param() params: NicknameParamDto,

--- a/backend/nestjs-app/src/match_history/history.service.ts
+++ b/backend/nestjs-app/src/match_history/history.service.ts
@@ -11,16 +11,17 @@ export class MatchHistorysService {
     @InjectRepository(MatchHistoryRepository)
     private matchHistoryRepository: MatchHistoryRepository,
   ) {}
-
-  async putHistory(historyDto: HistoryDto, player1: User, player2: User) {
+  putHistory(historyDto: HistoryDto) {
     const history = new MatchHistory();
-    if (!player1 || !player2) throw new BadRequestException('not exist user');
-    history.player1 = player1;
-    history.player1Score = historyDto.player1score;
-    history.player2 = player2;
-    history.player2Score = historyDto.player2score;
-    history.gameMode = historyDto.gameMode;
-    // TODO: gameResultProcess에서 계산된 변화하는 rating을 넣어줘야함
+    history.player1 = historyDto.player1;
+    history.player1Score = historyDto.player1Score;
+    history.player1ScoreChange = historyDto.player1ScoreChange;
+    history.player2 = historyDto.player2;
+    history.player2Score = historyDto.player2Score;
+    history.player2ScoreChange = historyDto.player2ScoreChange;
+    history.roomType = historyDto.roomType;
+    history.map = historyDto.map;
+    history.createdAt = new Date();
     this.matchHistoryRepository.putHistory(history);
   }
 

--- a/backend/nestjs-app/src/match_history/repository/history.repository.ts
+++ b/backend/nestjs-app/src/match_history/repository/history.repository.ts
@@ -6,8 +6,8 @@ import { HistoryDto } from 'src/match_history/dto/history.dto';
 
 @CustomRepository(MatchHistory)
 export class MatchHistoryRepository extends Repository<MatchHistory> {
-  async putHistory(history: MatchHistory) {
-    await this.save(history);
+  putHistory(history: MatchHistory) {
+    this.save(history);
   }
 
   async getHistoryJoinUserByNickname(

--- a/frontend/react-app/src/api/game.ts
+++ b/frontend/react-app/src/api/game.ts
@@ -1,0 +1,15 @@
+import axios, { AxiosResponse } from "axios";
+import * as cookies from "react-cookies";
+import { base_url } from "./index";
+import { MatchHistoryType } from "@src/types";
+
+export const getHistoryById = async (
+  id: string,
+): Promise<AxiosResponse<MatchHistoryType[]>> => {
+  const response = await axios.get(`${base_url}/MatchHistory/${id}`, {
+    headers: {
+      Authorization: `Bearer ${cookies.load("jwt") as string}`,
+    },
+  });
+  return response;
+};

--- a/frontend/react-app/src/components/common/sideBar/userListSideBar/index.tsx
+++ b/frontend/react-app/src/components/common/sideBar/userListSideBar/index.tsx
@@ -4,8 +4,7 @@ import { useRecoilState } from "recoil";
 import { allUserListState } from "@src/recoil/atoms/common";
 import { UserStatusCounts } from "@src/types/user.type";
 import { createDummy } from "@src/api";
-import { createDummyHistory } from "@src/recoil/atoms/game/createDummyHistory";
-import { matchHistoryListState } from "@src/recoil/atoms/game";
+// import { createDummyHistory } from "@src/recoil/atoms/game/createDummyHistory";
 
 interface UserListSideBarProps {
   onAllUsersClick: () => void;
@@ -27,7 +26,6 @@ const UserListSideBar: React.FC<UserListSideBarProps> = ({
   currentClick,
 }) => {
   const [allUserList] = useRecoilState(allUserListState);
-  const [, setMatchHistoryList] = useRecoilState(matchHistoryListState);
 
   // TODO: text2에 "0"인 경우는 추가 구현 사항
   const userButtonList: DoubleTextButtonProps[] = [
@@ -75,20 +73,20 @@ const UserListSideBar: React.FC<UserListSideBarProps> = ({
       },
       theme: "LIGHT",
     },
-    {
-      text1: "더미 전적 생성",
-      text2: "5000",
-      onClick: () => {
-        console.log("더미 전적 생성");
-        console.log(
-          "createDummyHistory",
-          createDummyHistory(allUserList, 5000),
-        );
-        const dummyHistory = createDummyHistory(allUserList, 5000);
-        setMatchHistoryList(dummyHistory);
-      },
-      theme: "LIGHT",
-    },
+    // {
+    //   text1: "더미 전적 생성",
+    //   text2: "5000",
+    //   onClick: () => {
+    //     console.log("더미 전적 생성");
+    //     console.log(
+    //       "createDummyHistory",
+    //       createDummyHistory(allUserList, 5000),
+    //     );
+    //     const dummyHistory = createDummyHistory(allUserList, 5000);
+    //     setMatchHistoryList(dummyHistory);
+    //   },
+    //   theme: "LIGHT",
+    // },
   ];
 
   return (

--- a/frontend/react-app/src/hooks/useInitializeState/index.tsx
+++ b/frontend/react-app/src/hooks/useInitializeState/index.tsx
@@ -6,7 +6,6 @@ import {
   gameRoomInfoInitState,
   gameRoomInfoState,
   gameRoomListState,
-  matchHistoryListState,
 } from "@src/recoil/atoms/game";
 import { battleActionModalState } from "@src/recoil/atoms/modal";
 import { UserType } from "@src/types";
@@ -19,7 +18,6 @@ const useInitializeState = () => {
   const setGameModal = useSetRecoilState(gameModalState);
   const setGameRoomList = useSetRecoilState(gameRoomListState);
   const setGameRoomInfo = useSetRecoilState(gameRoomInfoState);
-  const setMatchHistoryList = useSetRecoilState(matchHistoryListState);
   const setGameRoomChatList = useSetRecoilState(gameRoomChatListState);
 
   // 초기화 기능을 담당하는 함수
@@ -39,7 +37,6 @@ const useInitializeState = () => {
     setGameModal({ gameMap: null });
     setGameRoomList([]);
     setGameRoomInfo(gameRoomInfoInitState);
-    setMatchHistoryList([]);
     setGameRoomChatList([]);
   };
 

--- a/frontend/react-app/src/pages/profile/container.tsx
+++ b/frontend/react-app/src/pages/profile/container.tsx
@@ -97,7 +97,7 @@ export const MatchCard = ({ history }: MatchCardProps) => {
     <S.MatchCard mode={winLose}>
       <S.MatchCardMatchInfo>
         <S.MatchCardMatchInfoGameType mode={winLose}>
-          {history.gameMode === "normal" ? "일반" : "랭크"}
+          {history.roomType === "NORMAL" ? "일반" : "랭크"}
         </S.MatchCardMatchInfoGameType>
         <S.MatchCardMatchInfoDate>
           {createTimeAgo(history.createdAt.toString())}
@@ -118,9 +118,9 @@ export const MatchCard = ({ history }: MatchCardProps) => {
       </S.MatchCardProfile>
       <S.MatchCardScoreContainer>
         <S.MatchCardScoreMap>
-          {history.map === "normal"
+          {history.map === "NORMAL"
             ? "일반"
-            : history.map === "desert"
+            : history.map === "DESERT"
             ? "사막"
             : "정글"}
         </S.MatchCardScoreMap>
@@ -144,11 +144,11 @@ export const MatchCard = ({ history }: MatchCardProps) => {
         />
       </S.MatchCardProfile>
       <S.MatchCardScoreChangeContainer
-        mode={history.gameMode}
+        mode={history.roomType}
         $winLose={winLose}
       >
-        {history.gameMode === "rank" ? (winLose === "승리" ? "+" : "") : ""}
-        {history.gameMode === "rank" ? playerScoreChange : "-"}
+        {history.roomType === "RANKING" ? (winLose === "승리" ? "+" : "") : ""}
+        {history.roomType === "RANKING" ? playerScoreChange : "-"}
       </S.MatchCardScoreChangeContainer>
     </S.MatchCard>
   );
@@ -161,7 +161,7 @@ type MapStatsType = {
   totalLoseScore: number;
 };
 
-type MapType = "normal" | "desert" | "jungle";
+type MapType = "NORMAL" | "DESERT" | "JUNGLE";
 
 export const MatchHeader = ({
   userId,
@@ -173,21 +173,21 @@ export const MatchHeader = ({
 }: MatchHeaderProps) => {
   const [showDropdown, setShowDropdown] = useState(false);
   const [isOpenDropdown, setIsOpenDropdown] = useState(false);
-  const maps: MapType[] = ["normal", "desert", "jungle"];
+  const maps: MapType[] = ["NORMAL", "DESERT", "JUNGLE"];
   const mapStats: Record<MapType, MapStatsType> = {
-    normal: {
+    NORMAL: {
       wins: 0,
       losses: 0,
       totalScore: 0,
       totalLoseScore: 0,
     },
-    desert: {
+    DESERT: {
       wins: 0,
       losses: 0,
       totalScore: 0,
       totalLoseScore: 0,
     },
-    jungle: {
+    JUNGLE: {
       wins: 0,
       losses: 0,
       totalScore: 0,
@@ -349,38 +349,44 @@ export const MatchHeader = ({
             {maps.map((mapType) => (
               <S.HeaderMapStats key={mapType}>
                 <div>
-                  {mapType === "normal"
+                  {mapType === "NORMAL"
                     ? "일반"
-                    : mapType === "desert"
+                    : mapType === "DESERT"
                     ? "사막"
                     : "정글"}
                 </div>
-                <S.HeaderMapStatsWinRate
-                  $win={mapStats[mapType].wins}
-                  $lose={mapStats[mapType].losses}
-                >
-                  {(
-                    (mapStats[mapType].wins /
-                      (mapStats[mapType].wins + mapStats[mapType].losses)) *
-                    100
-                  ).toFixed(0)}
-                  {"%"}
-                </S.HeaderMapStatsWinRate>
-                <div style={{ marginLeft: "4px" }}>
-                  {mapStats[mapType].wins}승 {mapStats[mapType].losses}패
-                </div>
-                <S.HeaderMapStatsAvgScore
-                  $score={
-                    mapStats[mapType].totalScore /
-                    mapStats[mapType].totalLoseScore
-                  }
-                >
-                  {(
-                    mapStats[mapType].totalScore /
-                    mapStats[mapType].totalLoseScore
-                  ).toFixed(2)}
-                  :1 평점
-                </S.HeaderMapStatsAvgScore>
+                {mapStats[mapType].wins + mapStats[mapType].losses === 0 ? (
+                  <div>{`\u00A0\u00A0\u00A0`}대전 기록이 없습니다.</div>
+                ) : (
+                  <>
+                    <S.HeaderMapStatsWinRate
+                      $win={mapStats[mapType].wins}
+                      $lose={mapStats[mapType].losses}
+                    >
+                      {(
+                        (mapStats[mapType].wins /
+                          (mapStats[mapType].wins + mapStats[mapType].losses)) *
+                        100
+                      ).toFixed(0)}
+                      {"%"}
+                    </S.HeaderMapStatsWinRate>
+                    <div style={{ marginLeft: "4px" }}>
+                      {mapStats[mapType].wins}승 {mapStats[mapType].losses}패
+                    </div>
+                    <S.HeaderMapStatsAvgScore
+                      $score={
+                        mapStats[mapType].totalScore /
+                        mapStats[mapType].totalLoseScore
+                      }
+                    >
+                      {(
+                        mapStats[mapType].totalScore /
+                        mapStats[mapType].totalLoseScore
+                      ).toFixed(2)}
+                      :1 평점
+                    </S.HeaderMapStatsAvgScore>
+                  </>
+                )}
               </S.HeaderMapStats>
             ))}
           </S.HeaderMapContainer>

--- a/frontend/react-app/src/pages/profile/index.styled.ts
+++ b/frontend/react-app/src/pages/profile/index.styled.ts
@@ -390,9 +390,9 @@ export const MatchCardScoreChangeContainer = styled.div<{
   font-weight: bold;
   font-family: inter;
   color: ${(props) =>
-    props.mode === "rank" && props.$winLose === "승리"
+    props.mode === "RANKING" && props.$winLose === "승리"
       ? "blue"
-      : props.mode === "rank" && props.$winLose === "패배"
+      : props.mode === "RANKING" && props.$winLose === "패배"
       ? "red"
       : props.theme.colors.heavyPurple};
 `;

--- a/frontend/react-app/src/recoil/atoms/game/createDummyHistory.ts
+++ b/frontend/react-app/src/recoil/atoms/game/createDummyHistory.ts
@@ -49,7 +49,7 @@ export const createDummyHistory = (
       player2,
       player1ScoreChange,
       player2ScoreChange,
-      gameMode: Math.random() < 0.5 ? "rank" : "normal", // 수정된 게임 모드 랜덤 선택 로직
+      roomType: Math.random() < 0.5 ? "rank" : "normal", // 수정된 게임 모드 랜덤 선택 로직
       map: maps[Math.floor(Math.random() * maps.length)],
     });
   }

--- a/frontend/react-app/src/recoil/atoms/game/index.ts
+++ b/frontend/react-app/src/recoil/atoms/game/index.ts
@@ -1,7 +1,6 @@
 import { UserType } from "@src/types";
 import {
   GameRoomInfoType,
-  MatchHistoryType,
   GameRoomType,
   GameRoomStatus,
   GameModalType,
@@ -11,12 +10,6 @@ import { atom } from "recoil";
 import { recoilPersist } from "recoil-persist";
 
 const { persistAtom } = recoilPersist();
-
-export const matchHistoryListState = atom<MatchHistoryType[]>({
-  key: "matchHistoryListState",
-  default: [],
-  effects_UNSTABLE: [persistAtom],
-});
 
 export const gameRoomURLState = atom<string>({
   key: "gameRoomURLState",

--- a/frontend/react-app/src/types/game.type.ts
+++ b/frontend/react-app/src/types/game.type.ts
@@ -17,7 +17,7 @@ export interface MatchHistoryType {
   player2: UserType;
   player1ScoreChange: number;
   player2ScoreChange: number;
-  gameMode: string;
+  roomType: string;
   map: string;
 }
 


### PR DESCRIPTION
close #147
## 🔎 What is this PR?

프로필 페이지 접근 시, 해당 유저의 전적만 불러오는것으로 변경하였습니다.

## 📝 Changes

- 기존 사용하던 리코일 상태 제거
- 해당 유저의 전적을 가져오는 api 추가

## 📸 Screenshot

- 데이터베이스에서 가져온 전적이 표시되는 모습
![스크린샷 2023-09-10 오전 12 34 02](https://github.com/42ft-transcendence/transcendence/assets/84218652/3e5bb8c4-1dc2-45e9-b561-b96b240d9470)
![스크린샷 2023-09-10 오전 12 34 23](https://github.com/42ft-transcendence/transcendence/assets/84218652/837ee259-bb39-453c-849f-d7942cc94b85)

## ✅ Test Checklist

- 테스트 계획 또는 완료 사항

## 📮 To Reviewers

- 어떤 부분에 리뷰어가 집중하면 좋을지
- 전달할 말
- 고민사항

