### PR TITLE
[Feat] 폰트, 라우팅, chatting 소켓 반환형

### DIFF
--- a/backend/nestjs-app/src/chatting/chatting.gateway.ts
+++ b/backend/nestjs-app/src/chatting/chatting.gateway.ts
@@ -117,7 +117,7 @@ export class ChattingGateway
           user,
           message,
         });
-        return { user, message };
+        return { message };
       }
     } catch (e) {
       console.log(e);
@@ -428,7 +428,7 @@ export class ChattingGateway
         user: user,
         message: dm,
       });
-      return dm;
+      return { message: dm };
     } catch (e) {
       console.log(e);
     }

--- a/frontend/react-app/index.html
+++ b/frontend/react-app/index.html
@@ -2,11 +2,11 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link
-      rel="shortcut icon"
-      href="http://localhost/files/images/favicon.ico"
-    />
+    <link rel="shortcut icon" href="http://localhost/files/images/favicon.ico" />
     <link rel="icon" href="http://localhost/files/images/favicon.ico" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Noto+Sans+KR:wght@500;700&family=Noto+Sans+Mono:wght@700&display=swap" rel="stylesheet">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>칙칙퐁퐁</title>
   </head>

--- a/frontend/react-app/src/components/modal/auth/secondAuthActivateModal/index.styled.ts
+++ b/frontend/react-app/src/components/modal/auth/secondAuthActivateModal/index.styled.ts
@@ -51,7 +51,8 @@ export const Input = styled.input`
   padding-left: 10px;
   width: 240px;
   height: 40px;
-  font-family: monospace;
+  font-family: "Noto Sans Mono";
+  font-weight: 700;
   font-size: 24px;
   letter-spacing: 1em;
   background: none;

--- a/frontend/react-app/src/pages/auth/index.styled.ts
+++ b/frontend/react-app/src/pages/auth/index.styled.ts
@@ -42,7 +42,8 @@ export const TwoFactorInput = styled.input`
   padding-left: 10px;
   width: 240px;
   height: 40px;
-  font-family: monospace;
+  font-family: "Noto Sans Mono";
+  font-weight: 700;
   font-size: 24px;
   letter-spacing: 1em;
   background: none;

--- a/frontend/react-app/src/router/index.tsx
+++ b/frontend/react-app/src/router/index.tsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter } from "react-router-dom";
+import { Navigate, createBrowserRouter } from "react-router-dom";
 import PrivateRoute from "./PrivateRoute";
 import AuthPage from "@pages/auth";
 import Login from "@pages/login";
@@ -122,10 +122,10 @@ const Router = createBrowserRouter([
       </Socket>
     ),
   },
-  // {
-  //   path: "/channel/:channelId",
-  //   element: <ChannelPage />,
-  // },
+  {
+    path: "*",
+    element: <Navigate to="/" />,
+  },
 ]);
 
 export default Router;

--- a/frontend/react-app/src/styles/GlobalStyle.tsx
+++ b/frontend/react-app/src/styles/GlobalStyle.tsx
@@ -27,7 +27,7 @@ const GlobalStyle = createGlobalStyle`
   body {
     margin: 0;
     line-height: 1.5;
-    font-family: Roboto sans-serif;
+    font-family: 'Inter', 'Noto Sans KR';
     color: ${({ theme }) => theme.colors.heavyPurple};
     font-size: 16px;
     background-color: ${({ theme }) => theme.colors.freezePurple};
@@ -90,7 +90,6 @@ const GlobalStyle = createGlobalStyle`
   input,
   button,
   select {
-    font-family: 'Noto Sans KR', sans-serif;
     vertical-align: middle;
   }
 


### PR DESCRIPTION
close #154 
close #155 
close #157 

## 🔎 What is this PR?

- 폰트를 통일하고 구글 폰트 링크를 추가하여 다영한 환경에서 직접 설정한 폰트를 사용할 수 있게 합니다.
- 사용하지 않는 경로로 진입할 경우 루트 페이지로 리다이렉트합니다.
- send_message에서 사용하지 않는 반환형을 지우고 send_dm의 반환형을 수정합니다.

## 📝 Changes

- monospace -> Noto Sans Mono 폰트 변경
- index.html에 google 폰트 링크 적용
- route table 맨 아래에 default 라우팅 적용 -> 루트로 리다이렉트
- send_message, send_dm 반환형 수정
